### PR TITLE
Bump base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/binder:4.3.1
+FROM rocker/binder:4.3.2
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM rocker/binder:4.3.2
 
-USER root
-
-# Install python packages as root, since that's what is done upstream
-# This may change soon https://github.com/rocker-org/rocker-versioned2/issues/670
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
-
-USER ${NB_USER}
 
 # Install learnr and other requested packages in https://2i2c.freshdesk.com/a/tickets/741
 # mosaic installed per https://2i2c.freshdesk.com/a/tickets/973

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ nbgitpuller==1.2.0
 
 jupyter-shiny-proxy==1.1
 # Based on request from Nathan Taback
-otter-grader==4.3.4
+otter-grader==5.2.2


### PR DESCRIPTION
- Bump otter-grader too
- Bring in new version of R
- Don't install python packages as root