### PR TITLE
Install packages needed for quarto to knit to PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
 # Install packages needed for quarto knitting to PDF
-RUN tlmgr install \
+RUN tlmgr update --self && \
+    tlmgr install \
     scrartcl.cls \
     footnote.sty \
     tikzfill.image.sty \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN pip install --no-cache -r /tmp/requirements.txt
 
 # Install packages needed for quarto knitting to PDF
 RUN tlmgr install \
-    scrartcl \
-    footnote \
-    tikzfill.image \
+    koma-script \
+    mdwtools \
+    tikzfill \
     bookmark
 
 USER ${NB_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ USER root
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
+# Install packages needed for quarto knitting to PDF
+RUN tlmgr install \
+    scrartcl.cls \
+    footnote.sty \
+    tikzfill.image.sty \
+    bookmark.sty
+
 USER ${NB_USER}
 
 # Install learnr and other requested packages in https://2i2c.freshdesk.com/a/tickets/741

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,11 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
 # Install packages needed for quarto knitting to PDF
-RUN tlmgr update --self && \
-    tlmgr install \
-    scrartcl.cls \
-    footnote.sty \
-    tikzfill.image.sty \
-    bookmark.sty
+RUN tlmgr install \
+    scrartcl \
+    footnote \
+    tikzfill.image \
+    bookmark
 
 USER ${NB_USER}
 


### PR DESCRIPTION
Package list comes from the log provided by
Nathan in https://2i2c.freshdesk.com/a/tickets/952, listing the packages needed by quarto PDF knitting.

Ref https://github.com/2i2c-org/infrastructure/issues/2729